### PR TITLE
Fix issue with /* */ comment cases in cpp_tokenizer.py 

### DIFF
--- a/sctokenizer/cpp_tokenizer.py
+++ b/sctokenizer/cpp_tokenizer.py
@@ -61,7 +61,7 @@ class CppTokenizer(Tokenizer):
                     if next == '/':
                         self.colnumber = i
                         self.add_pending(tokens, '*/', TokenType.COMMENT_SYMBOL, len_lines, t)
-                        i += 1
+                        i += 2
                         state = TokenizerState.REGULAR
                         continue
 


### PR DESCRIPTION
In the previous pull request #8, I forgot to skip `/` in the case of `/* */`

I modified the `cur == '*'` case to skip 2 tokens instead of 1 (`i+=2`)