### PR TITLE
tokenizers: use line length prefix sum instead of plain array

### DIFF
--- a/sctokenizer/tokenizer.py
+++ b/sctokenizer/tokenizer.py
@@ -24,12 +24,17 @@ class Tokenizer():
     def tokenize(self):
         pass
 
-    def add_pending(self, tokens, pending, token_type, len_lines, t):
+    def compute_line_starts(self, source_str):
+        lines = source_str.split('\n')
+        len_lines = [0]
+        for x in lines:
+            len_lines.append(len_lines[-1] + len(x) + 1)
+        return len_lines
+
+    def add_pending(self, tokens, pending, token_type, line_starts, t):
         if pending <= ' ':
             return
-        for k in range(t):
-            self.colnumber -= (len_lines[k] + 1)
-        
+        self.colnumber -= line_starts[t]
         if pending in self.operator_set:
             tokens.append(Token(pending, TokenType.OPERATOR, self.linenumber, self.colnumber + 1))
         elif pending in self.keyword_set:


### PR DESCRIPTION
First of all hi and thanks for your project, it has been really useful!

I noticed however that tokenizing the source code gets rather slow for big source files. After some investigation, I think I figured out the problem: in `add_pending()`, we subtract the length of all lines before the current one to get the position in the current line. But the problem is, this iteration is quadratic time and this is problematic for longer files.

Instead, it would be better to not have a list of the lengths of individual lines, but a list of the start positions for each line (it is basically a prefix sum). This way we can use simple subtraction instead of a loop, making the algorithm linear. In practice I have observed this makes parsing much faster (I test with files which are >2000 lines long).

I hope you find this change useful :)